### PR TITLE
Merge FromWallet and FromWalletUtxo intents

### DIFF
--- a/.github/workflows/elm.yml
+++ b/.github/workflows/elm.yml
@@ -76,6 +76,7 @@ jobs:
       - run: cd examples/txbuild && elm make src/Main.elm --output /dev/null
       - run: cd examples/decode-data-custom-type && elm make src/Main.elm --output /dev/null
       - run: cd examples/aiken-hello-world && elm make src/Main.elm --output /dev/null
+      - run: cd examples/aiken-gift-card && elm make src/Main.elm --output /dev/null
       - run: cd examples/smart-bucket && elm make src/Main.elm --output /dev/null
       - run: cd examples/fee-provider && elm make src/Main.elm src/External.elm --output /dev/null
       - run: cd examples/vote-script && elm make src/Main.elm src/External.elm --output /dev/null

--- a/examples/fee-provider/aiken.toml
+++ b/examples/fee-provider/aiken.toml
@@ -1,6 +1,5 @@
 name = "aiken-lang/hello-world"
 version = "0.0.0"
-compiler = "v1.1.3"
 plutus = "v3"
 license = "Apache-2.0"
 description = "Aiken contracts for project 'aiken-lang/hello-world'"

--- a/examples/smart-bucket/README.md
+++ b/examples/smart-bucket/README.md
@@ -5,6 +5,8 @@ that enables locking some utxos reusable by anyone, as long as they are put back
 I call such a utxo a "bucket".
 In this example, the bucket is limited to (testnet) ada and iUSD.
 But the iUSD policy could be replaced by any policy really.
+If you don’t replace the token policy ID by something you own,
+the second Tx ("Reuse the bucket") will fail to perform coin selection.
 
 ```sh
 # build the aiken contract

--- a/examples/smart-bucket/aiken.toml
+++ b/examples/smart-bucket/aiken.toml
@@ -1,6 +1,5 @@
 name = "elm-cardano/smart-bucket"
 version = "0.0.0"
-compiler = "v1.1.3"
 plutus = "v3"
 license = "Apache-2.0"
 description = "Aiken contracts for project 'elm-cardano/smart-bucket'"

--- a/examples/smart-bucket/src/Main.elm
+++ b/examples/smart-bucket/src/Main.elm
@@ -336,7 +336,7 @@ update msg model =
                                 }
                             }
                         )
-                    , Spend <| FromWallet ctx.loadedWallet.changeAddress bucketValueIncrease
+                    , Spend <| FromWallet { address = ctx.loadedWallet.changeAddress, value = bucketValueIncrease, guaranteedUtxos = [] }
                     , SendToOutputAdvanced outputBucket
                     ]
                         |> Cardano.finalize ctx.localStateUtxos []
@@ -373,7 +373,7 @@ createBucket ({ localStateUtxos, myKeyCred, scriptAddress, loadedWallet, lockScr
 
         -- Transaction locking 2 Ada in a "bucket" UTxO at the script address
         createBucketTxAttempt =
-            [ Spend (FromWallet loadedWallet.changeAddress twoAda)
+            [ Spend <| FromWallet { address = ctx.loadedWallet.changeAddress, value = twoAda, guaranteedUtxos = [] }
             , SendToOutput
                 { address = scriptAddress
                 , amount = twoAda

--- a/examples/smart-bucket/validators/smart_bucket.ak
+++ b/examples/smart-bucket/validators/smart_bucket.ak
@@ -28,7 +28,7 @@ validator token_bucket {
   ) {
     // If it’s the owner signing, they can do whatever
     // Otherwise, let’s check that all invariants are respected
-    expect Some(Datum { owner, input_bucket_index }) = datum
+    expect Some(Datum { owner, .. }) = datum
     if list.has(self.extra_signatories, owner) {
       True
     } else {

--- a/examples/vote-script/aiken.toml
+++ b/examples/vote-script/aiken.toml
@@ -1,6 +1,5 @@
 name = "aiken-lang/hello-world"
 version = "0.0.0"
-compiler = "v1.1.3"
 plutus = "v3"
 license = "Apache-2.0"
 description = "Aiken contracts for project 'aiken-lang/hello-world'"

--- a/examples/vote-script/validators/drep.ak
+++ b/examples/vote-script/validators/drep.ak
@@ -17,21 +17,21 @@ validator drep_voting {
     list.has(self.extra_signatories, owner)?
   }
 
-  publish(_redeemer: Data, certificate: Certificate, self: Transaction) {
+  publish(_redeemer: Data, certificate: Certificate, _self: Transaction) {
     when certificate is {
-      RegisterDelegateRepresentative { delegate_representative, deposit } ->
+      RegisterDelegateRepresentative { .. } ->
         // todo @"register"
         True
-      UnregisterDelegateRepresentative { delegate_representative, refund } ->
+      UnregisterDelegateRepresentative { .. } ->
         // todo @"unregister"
         True
       _ -> fail
     }
   }
 
-  vote(_redeemer: Data, voter: Voter, self: Transaction) {
+  vote(_redeemer: Data, voter: Voter, _self: Transaction) {
     when voter is {
-      DelegateRepresentative(cred) ->
+      DelegateRepresentative(_) ->
         // todo @"drep"
         True
       _ -> fail

--- a/examples/wallet-cip30/src/Main.elm
+++ b/examples/wallet-cip30/src/Main.elm
@@ -6,7 +6,7 @@ import Bytes.Encode
 import Cardano exposing (SpendSource(..), TxIntent(..))
 import Cardano.Address as Address exposing (Address)
 import Cardano.Cip30 as Cip30
-import Cardano.Transaction as Transaction exposing (Transaction)
+import Cardano.Transaction exposing (Transaction)
 import Cardano.Utxo as Utxo
 import Cardano.Value as CValue
 import Dict exposing (Dict)
@@ -297,11 +297,8 @@ update msg model =
                         localStateUtxos =
                             Utxo.refDictFromList utxos
 
-                        oneAda =
-                            CValue.onlyLovelace (N.fromSafeString "1000000")
-
                         txIntents =
-                            [ Spend (FromWallet address oneAda), SendTo address oneAda ]
+                            [ SendTo address CValue.zero ]
                     in
                     case Cardano.finalize localStateUtxos [] txIntents of
                         Ok { tx } ->

--- a/src/Cardano/TxExamples.elm
+++ b/src/Cardano/TxExamples.elm
@@ -100,7 +100,7 @@ globalStateUtxos =
 
 
 example1 _ =
-    [ Spend <| FromWallet exAddr.me ada.one
+    [ Spend <| FromWallet { address = exAddr.me, value = ada.one, guaranteedUtxos = [] }
     , SendTo exAddr.you ada.one
     ]
         |> finalize globalStateUtxos [ TxMetadata { tag = Natural.fromSafeInt 14, metadata = Metadatum.Int (Integer.fromSafeInt 42) } ]
@@ -120,7 +120,12 @@ example2 _ =
     , SendTo exAddr.me (Value.onlyToken dog.policyId dog.assetName Natural.one)
 
     -- burning 1 cat
-    , Spend <| FromWallet exAddr.me (Value.onlyToken cat.policyId cat.assetName Natural.one)
+    , Spend <|
+        FromWallet
+            { address = exAddr.me
+            , value = Value.onlyToken cat.policyId cat.assetName Natural.one
+            , guaranteedUtxos = []
+            }
     , MintBurn
         { policyId = cat.policyId
         , assets = Map.singleton cat.assetName Integer.negativeOne
@@ -224,7 +229,7 @@ example4 _ =
             Address.extractStakeKeyHash exAddr.me
                 |> Maybe.withDefault (dummyCredentialHash "ERROR")
     in
-    [ Spend <| FromWallet exAddr.me ada.two -- 2 ada for the registration deposit
+    [ Spend <| FromWallet { address = exAddr.me, value = ada.two, guaranteedUtxos = [] }
     , IssueCertificate <| RegisterStake { delegator = WithKey myStakeKeyHash, deposit = Natural.fromSafeInt 2000000 }
     , IssueCertificate <| DelegateStake { delegator = WithKey myStakeKeyHash, poolId = Bytes.dummy 28 "poolId" }
     , IssueCertificate <| DelegateVotes { delegator = WithKey myStakeKeyHash, drep = VKeyHash <| dummyCredentialHash "drep" }
@@ -291,7 +296,12 @@ example5 _ =
                 }
     in
     [ -- 600K deposit for all the gov actions
-      Spend <| FromWallet exAddr.me <| Value.onlyLovelace (Natural.mul Natural.six ada100K)
+      Spend <|
+        FromWallet
+            { address = exAddr.me
+            , value = Value.onlyLovelace (Natural.mul Natural.six ada100K)
+            , guaranteedUtxos = []
+            }
 
     -- Change minPoolCost to 0
     , propose

--- a/tests/Cardano/TxBuilding.elm
+++ b/tests/Cardano/TxBuilding.elm
@@ -99,7 +99,7 @@ okTxBuilding =
             , fee = twoAdaFee
             , txOtherInfo = []
             , txIntents =
-                [ Spend <| FromWallet testAddr.me (Value.onlyLovelace <| ada 1)
+                [ Spend <| FromWallet { address = testAddr.me, value = Value.onlyLovelace <| ada 1, guaranteedUtxos = [] }
                 , SendTo testAddr.me (Value.onlyLovelace <| ada 1)
                 ]
             }
@@ -123,7 +123,7 @@ okTxBuilding =
                         Utxo.refDictFromList [ makeAdaOutput 0 testAddr.me 5 ]
 
                     txIntents =
-                        [ Spend <| FromWallet testAddr.me (Value.onlyLovelace <| ada 1)
+                        [ Spend <| FromWallet { address = testAddr.me, value = Value.onlyLovelace <| ada 1, guaranteedUtxos = [] }
                         , SendTo testAddr.me (Value.onlyLovelace <| ada 1)
                         ]
                 in
@@ -135,7 +135,7 @@ okTxBuilding =
             , fee = twoAdaFee
             , txOtherInfo = []
             , txIntents =
-                [ Spend <| FromWallet testAddr.me (Value.onlyLovelace <| ada 1)
+                [ Spend <| FromWallet { address = testAddr.me, value = Value.onlyLovelace <| ada 1, guaranteedUtxos = [] }
                 , SendTo testAddr.you (Value.onlyLovelace <| ada 1)
                 ]
             }
@@ -165,7 +165,7 @@ okTxBuilding =
             , fee = twoAdaFee
             , txOtherInfo = []
             , txIntents =
-                [ Spend <| FromWallet testAddr.you (Value.onlyLovelace <| ada 1)
+                [ Spend <| FromWallet { address = testAddr.you, value = Value.onlyLovelace <| ada 1, guaranteedUtxos = [] }
                 , SendTo testAddr.me (Value.onlyLovelace <| ada 1)
                 ]
             }
@@ -205,7 +205,7 @@ okTxBuilding =
             , fee = twoAdaFee
             , txOtherInfo = []
             , txIntents =
-                [ Spend <| FromWallet testAddr.me threeCatTwoAda
+                [ Spend <| FromWallet { address = testAddr.me, value = threeCatTwoAda, guaranteedUtxos = [] }
                 , SendTo testAddr.you threeCatTwoAda
                 ]
             }
@@ -245,7 +245,7 @@ okTxBuilding =
             , fee = twoAdaFee
             , txOtherInfo = []
             , txIntents =
-                [ Spend <| FromWallet testAddr.me threeCatMinAda
+                [ Spend <| FromWallet { address = testAddr.me, value = threeCatMinAda, guaranteedUtxos = [] }
                 , SendTo testAddr.you threeCatMinAda
                 ]
             }
@@ -286,7 +286,12 @@ okTxBuilding =
                 , SendTo testAddr.me (Value.onlyToken dog.policyId dog.assetName Natural.one)
 
                 -- burning 1 cat
-                , Spend <| FromWallet testAddr.me (Value.onlyToken cat.policyId cat.assetName Natural.one)
+                , Spend <|
+                    FromWallet
+                        { address = testAddr.me
+                        , value = Value.onlyToken cat.policyId cat.assetName Natural.one
+                        , guaranteedUtxos = []
+                        }
                 , MintBurn
                     { policyId = cat.policyId
                     , assets = Map.singleton cat.assetName Integer.negativeOne
@@ -455,7 +460,12 @@ okTxBuilding =
             , fee = twoAdaFee
             , txOtherInfo = []
             , txIntents =
-                [ Spend <| FromWallet testAddr.me <| Value.onlyLovelace (ada 2) -- 2 ada for the registration deposit
+                [ Spend <|
+                    FromWallet
+                        { address = testAddr.me
+                        , value = Value.onlyLovelace (ada 2) -- 2 ada for the registration deposit
+                        , guaranteedUtxos = []
+                        }
                 , IssueCertificate <| RegisterStake { delegator = WithKey myStakeKeyHash, deposit = ada 2 }
                 , IssueCertificate <| DelegateStake { delegator = WithKey myStakeKeyHash, poolId = Bytes.dummy 28 "poolId" }
                 , IssueCertificate <| DelegateVotes { delegator = WithKey myStakeKeyHash, drep = VKeyHash <| dummyCredentialHash "drep" }
@@ -540,7 +550,12 @@ okTxBuilding =
             , txOtherInfo = []
             , txIntents =
                 [ -- 600K deposit for all the gov actions
-                  Spend <| FromWallet testAddr.me <| Value.onlyLovelace (Natural.mul Natural.six ada100K)
+                  Spend <|
+                    FromWallet
+                        { address = testAddr.me
+                        , value = Value.onlyLovelace (Natural.mul Natural.six ada100K)
+                        , guaranteedUtxos = []
+                        }
 
                 -- Change minPoolCost to 0
                 , propose
@@ -808,7 +823,12 @@ failTxBuilding =
             , fee = twoAdaFee
             , txOtherInfo = []
             , txIntents =
-                [ Spend <| FromWalletUtxo (makeRef "0" 0)
+                [ Spend <|
+                    FromWallet
+                        { address = testAddr.me
+                        , value = Value.onlyLovelace <| ada 1
+                        , guaranteedUtxos = [ makeRef "0" 0 ] -- Non-existent UTxO
+                        }
                 , SendTo testAddr.me (Value.onlyLovelace <| ada 1)
                 ]
             }
@@ -826,7 +846,7 @@ failTxBuilding =
             , evalScriptsCosts = \_ _ -> Ok []
             , fee = twoAdaFee
             , txOtherInfo = []
-            , txIntents = [ Spend <| FromWallet testAddr.me (Value.onlyLovelace <| ada 1) ]
+            , txIntents = [ Spend <| FromWallet { address = testAddr.me, value = Value.onlyLovelace <| ada 1, guaranteedUtxos = [] } ]
             }
             (\error ->
                 case error of
@@ -859,7 +879,7 @@ failTxBuilding =
             , fee = twoAdaFee
             , txOtherInfo = []
             , txIntents =
-                [ Spend <| FromWallet testAddr.me (Value.onlyLovelace <| Natural.fromSafeInt 100)
+                [ Spend <| FromWallet { address = testAddr.me, value = Value.onlyLovelace <| Natural.fromSafeInt 100, guaranteedUtxos = [] }
                 , SendToOutput (Utxo.fromLovelace testAddr.me <| Natural.fromSafeInt 100)
                 ]
             }
@@ -881,7 +901,12 @@ failTxBuilding =
             , fee = twoAdaFee
             , txOtherInfo = []
             , txIntents =
-                [ Spend <| FromWallet testAddr.me (Value.onlyToken cat.policyId cat.assetName Natural.three)
+                [ Spend <|
+                    FromWallet
+                        { address = testAddr.me
+                        , value = Value.onlyToken cat.policyId cat.assetName Natural.three
+                        , guaranteedUtxos = []
+                        }
                 , SendTo testAddr.you (Value.onlyToken cat.policyId cat.assetName Natural.three)
                 ]
             }


### PR DESCRIPTION
This is the implementation of the improvement mentioned in #86. Both spending intents from a wallet address have been merged into a single intent. So instead of

```elm
type SpendSource
    = FromWallet Address Value
    | FromWalletUtxo OutputReference
    | ...
```
We now have
```elm
type SpendSource
    = FromWallet
        { address : Address
        , value : Value
        , guaranteedUtxos : List OutputReference
        }
    | ...
```
This change make it easier to guaranty that some UTxO is spent, but we do not need to retrieve the amount contained in that spent UTxO, and to balance it. Only the `value` is used to check the balance of the intents. One common use case is parameterization of a script with a unique UTxO to be spent, to make sure the minted token is unique.