### PR TITLE
Replace InputsOutputs by TransactionBody in intents

### DIFF
--- a/examples/smart-bucket/src/Main.elm
+++ b/examples/smart-bucket/src/Main.elm
@@ -280,14 +280,14 @@ update msg model =
 
                 -- The datum of the new output bucket should contain the same owner,
                 -- and the index of the input utxo of the corresponding bucket that is spent.
-                outputBucket { spentInputs } =
+                outputBucket { inputs } =
                     { address = ctx.scriptAddress
                     , amount = Value.add spentBucket.amount bucketValueIncrease
                     , datumOption =
                         let
                             -- The input index is easy to find, just look for the correct ref in inputs
                             input_bucket_index =
-                                findIndex (\ref -> ref == bucketRef) spentInputs
+                                findIndex (\ref -> ref == bucketRef) inputs
                                     -- Put a huge default, just to make sure it’s found
                                     |> Maybe.withDefault 7000
                                     |> Integer.fromSafeInt
@@ -301,11 +301,11 @@ update msg model =
                 -- The redeemer needs to provide the index of that bucket we spend
                 -- in the list of the Tx inputs,
                 -- and the index of that new bucket we create in the Tx outputs.
-                redeemerData { spentInputs, createdOutputs } =
+                redeemerData { inputs, outputs } =
                     let
                         -- The input index is easy to find, just look for the correct ref
                         input_bucket_index =
-                            findIndex (\ref -> ref == bucketRef) spentInputs
+                            findIndex (\ref -> ref == bucketRef) inputs
                                 -- Put a huge default, just to make sure it’s found
                                 |> Maybe.withDefault 8000
 
@@ -313,7 +313,7 @@ update msg model =
                         -- it is the only one at the script address,
                         -- that contains a datum with the same owner as the input
                         output_bucket_index =
-                            findIndex (\o -> extractOwner o == bucketOwner) createdOutputs
+                            findIndex (\o -> extractOwner o == bucketOwner) outputs
                                 -- Put a huge default, just to make sure it’s found
                                 |> Maybe.withDefault 9000
                     in

--- a/src/Cardano/TxExamples.elm
+++ b/src/Cardano/TxExamples.elm
@@ -181,8 +181,8 @@ example3 _ =
                 }
 
         -- Build a redeemer that contains the index of the spent script input.
-        redeemer inputsOutputs =
-            List.indexedMap Tuple.pair inputsOutputs.spentInputs
+        redeemer txBody =
+            List.indexedMap Tuple.pair txBody.inputs
                 |> findSpendingUtxo
                 |> (Data.Int << Integer.fromSafeInt)
 

--- a/tests/Cardano/HardwareWallet.elm
+++ b/tests/Cardano/HardwareWallet.elm
@@ -215,8 +215,8 @@ suite =
                             }
 
                     -- Build a redeemer that contains the index of the spent script input.
-                    redeemer inputsOutputs =
-                        List.indexedMap Tuple.pair inputsOutputs.spentInputs
+                    redeemer txBody =
+                        List.indexedMap Tuple.pair txBody.inputs
                             |> findSpendingUtxo
                             |> (Data.Int << Integer.fromSafeInt)
 

--- a/tests/Cardano/TxBuilding.elm
+++ b/tests/Cardano/TxBuilding.elm
@@ -368,8 +368,8 @@ okTxBuilding =
                     }
 
             -- Build a redeemer that contains the index of the spent script input.
-            redeemer inputsOutputs =
-                List.indexedMap Tuple.pair inputsOutputs.spentInputs
+            redeemer txBody =
+                List.indexedMap Tuple.pair txBody.inputs
                     |> findSpendingUtxo
                     |> (Data.Int << Integer.fromSafeInt)
 
@@ -993,8 +993,8 @@ failTxBuilding =
                     }
 
             -- Build a redeemer that contains the index of the spent script input.
-            redeemer inputsOutputs =
-                List.indexedMap Tuple.pair inputsOutputs.spentInputs
+            redeemer txBody =
+                List.indexedMap Tuple.pair txBody.inputs
                     |> findSpendingUtxo
                     |> (Data.Int << Integer.fromSafeInt)
 


### PR DESCRIPTION
Basically making advanced datum/redeemer creation able to inspect the whole Tx body of the current build pass.