### PR TITLE
Do not fully decode reference scripts

### DIFF
--- a/src/Cardano/Script.elm
+++ b/src/Cardano/Script.elm
@@ -52,7 +52,6 @@ type Reference
     = Reference
         { scriptHash : Bytes CredentialHash
         , bytes : Bytes Script
-        , script : Script
         }
 
 
@@ -72,13 +71,12 @@ refFromBytes bytes =
         elmBytes =
             Bytes.toBytes bytes
     in
-    case ( D.decode fromCbor elmBytes, D.decode taggedRawScriptDecoder elmBytes ) of
-        ( Just script, Just taggedScriptBytes ) ->
+    case D.decode taggedRawScriptDecoder elmBytes of
+        Just taggedScriptBytes ->
             Just <|
                 Reference
                     { scriptHash = Bytes.blake2b224 taggedScriptBytes
                     , bytes = bytes
-                    , script = script
                     }
 
         _ ->
@@ -92,15 +90,14 @@ refFromScript script =
     Reference
         { scriptHash = hash script
         , bytes = Bytes.fromBytes <| E.encode (toCbor script)
-        , script = script
         }
 
 
 {-| Extract the Script from a script Reference.
 -}
-refScript : Reference -> Script
-refScript (Reference { script }) =
-    script
+refScript : Reference -> Maybe Script
+refScript (Reference { bytes }) =
+    D.decode fromCbor (Bytes.toBytes bytes)
 
 
 {-| Extract the Bytes from a script Reference.

--- a/src/Cardano/Script.elm
+++ b/src/Cardano/Script.elm
@@ -255,7 +255,7 @@ Summary, with pseudo-code:
 
 1.  `flat_bytes`: the actual Plutus script bytes.
 2.  `cbor_bytes(flat_bytes)`: the thing that is provided in the `plutus.json` blueprint of an Aiken compilation.
-3.  `cbor_bytes(cbor_bytes(flat_bytes))`: the output you might see from some Cardano CLI tools.
+3.  `cbor_bytes(cbor_bytes(flat_bytes))`: how encoded in the witness set and by some CLI tools.
 4.  `tag + cbor_bytes(flat_bytes)`: the input of the Blake2b-224 hash to compute the script hash.
 5.  `cbor_array[cbor_int(tag), cbor_bytes(cbor_bytes(flat_bytes))]`: the thing transmitted in UTxO script references.
 

--- a/src/Cardano/TxExamples.elm
+++ b/src/Cardano/TxExamples.elm
@@ -831,11 +831,14 @@ prettyCbor toCbor x =
 
 prettyScriptRef scriptRef =
     case Script.refScript scriptRef of
-        Script.Native _ ->
+        Just (Script.Native _) ->
             "NativeScript: " ++ Bytes.toHex (Script.refBytes scriptRef)
 
-        Script.Plutus _ ->
+        Just (Script.Plutus _) ->
             "PlutusScript: " ++ Bytes.toHex (Script.refBytes scriptRef)
+
+        Nothing ->
+            "Invalid script ref: " ++ Bytes.toHex (Script.refBytes scriptRef)
 
 
 prettyScript script =

--- a/tests/Cardano/TransactionTests2.elm
+++ b/tests/Cardano/TransactionTests2.elm
@@ -44,6 +44,7 @@ suite =
         , decodeOutputfd83f4f9
         , decode437389ef
         , decode59fd3532
+        , decodeOutputa4005839
         ]
 
 
@@ -925,6 +926,19 @@ witnessSet59fd3532 =
                   }
                 ]
     }
+
+
+
+{-| Test decoding an output containing an invalid reference script (not cbor-wrapped).
+-}
+decodeOutputa4005839 : Test
+decodeOutputa4005839 =
+    test "Output a4005839... (ref script not cbor-wrapped)" <|
+        \_ ->
+            Bytes.fromHexUnchecked "a40058390068c14f253ceb1934ae8c69c68036273b425bdd3c86987c4d061e119cc043835c5336be17159088c24bf19b3a497106b3d4f41c95a1e860fb01821a01f97904a1581cd4c84babcb60f1e301fa4fd1c1759a2ebcd1d346988418ac459088e4a15653746172636164615265666572656e6365546f6b656e01028201d81846455374616d7003d818458201420101"
+                |> Bytes.toBytes
+                |> D.decode Utxo.decodeOutput
+                |> Expect.notEqual Nothing
 
 
 

--- a/tests/Cardano/TransactionTests2.elm
+++ b/tests/Cardano/TransactionTests2.elm
@@ -928,7 +928,6 @@ witnessSet59fd3532 =
     }
 
 
-
 {-| Test decoding an output containing an invalid reference script (not cbor-wrapped).
 -}
 decodeOutputa4005839 : Test


### PR DESCRIPTION
UTxOs can store reference scripts, but the content of these is not strictly validated by a Node. In practice Plutus scripts should be cbor-wrapped, put if they are not, we would fail trying to fully decode the reference script. This can cause issues when decoding wallet UTxOs for example, that may contain invalid reference scripts.

With this change, we do not fully decode reference scripts, just enough to compute the script hash (even if script is invalid).