### PR TITLE
Add many witness checks in Tx building

### DIFF
--- a/src/Cardano/Data.elm
+++ b/src/Cardano/Data.elm
@@ -1,8 +1,8 @@
-module Cardano.Data exposing (Data(..), fromCbor, toCbor, toCborUplc)
+module Cardano.Data exposing (Data(..), hash, fromCbor, toCbor, toCborUplc)
 
 {-| Handling Cardano Data objects.
 
-@docs Data, fromCbor, toCbor, toCborUplc
+@docs Data, hash, fromCbor, toCbor, toCborUplc, hash
 
 -}
 
@@ -25,6 +25,15 @@ type Data
     | List (List Data)
     | Int Integer
     | Bytes (Bytes Any)
+
+
+{-| Compute the Blake2b-256 (32 bytes) hash of a Data object.
+-}
+hash : Data -> Bytes a
+hash data =
+    E.encode (toCbor data)
+        |> Bytes.fromBytes
+        |> Bytes.blake2b256
 
 
 {-| CBOR encoder for [Data].

--- a/src/Cardano/Data.elm
+++ b/src/Cardano/Data.elm
@@ -2,7 +2,7 @@ module Cardano.Data exposing (Data(..), hash, fromCbor, toCbor, toCborUplc)
 
 {-| Handling Cardano Data objects.
 
-@docs Data, hash, fromCbor, toCbor, toCborUplc, hash
+@docs Data, hash, fromCbor, toCbor, toCborUplc
 
 -}
 

--- a/tests/Cardano/TxBuilding.elm
+++ b/tests/Cardano/TxBuilding.elm
@@ -1014,7 +1014,7 @@ failTxBuilding =
                 , ( utxoBeingSpent, makeLockedOutput <| Value.onlyLovelace <| ada 4 )
                 ]
           in
-          failTxTest "collateral insufficient in: spend 2 ada from a plutus script holding 4 ada"
+          failTxTest "when collateral is insufficient in: spend 2 ada from a plutus script holding 4 ada"
             { govState = Cardano.emptyGovernanceState
             , localStateUtxos = localStateUtxos
             , evalScriptsCosts = Uplc.evalScriptsCosts Uplc.defaultVmConfig
@@ -1041,6 +1041,575 @@ failTxBuilding =
             (\error ->
                 case error of
                     CollateralSelectionError (CoinSelection.UTxOBalanceInsufficient _) ->
+                        Expect.pass
+
+                    _ ->
+                        Expect.fail ("I didn’t expect this failure: " ++ Debug.toString error)
+            )
+
+        -- Test failing when providing the wrong native script in witness
+        , let
+            correctScript =
+                ScriptAny []
+
+            wrongScript =
+                ScriptAll []
+
+            utxoBeingSpent =
+                makeRef "previouslySentToLock" 0
+
+            localStateUtxos =
+                [ makeAdaOutput 0 testAddr.me 5
+                , ( utxoBeingSpent
+                  , { address = Address.script Mainnet (Script.hash <| Script.Native correctScript)
+                    , amount = Value.onlyLovelace (ada 4)
+                    , datumOption = Nothing
+                    , referenceScript = Nothing
+                    }
+                  )
+                ]
+          in
+          failTxTest "when providing the wrong native script witness"
+            { govState = Cardano.emptyGovernanceState
+            , localStateUtxos = localStateUtxos
+            , evalScriptsCosts = \_ _ -> Ok []
+            , fee = twoAdaFee
+            , txOtherInfo = []
+            , txIntents =
+                [ Spend <|
+                    FromNativeScript
+                        { spentInput = utxoBeingSpent
+                        , nativeScriptWitness = WitnessByValue wrongScript
+                        }
+                , SendTo testAddr.me (Value.onlyLovelace <| ada 4)
+                ]
+            }
+            (\error ->
+                case error of
+                    ScriptHashMismatch _ _ ->
+                        Expect.pass
+
+                    _ ->
+                        Expect.fail ("I didn’t expect this failure: " ++ Debug.toString error)
+            )
+
+        -- Test failing when providing the wrong native script in witness by reference
+        , let
+            correctScript =
+                ScriptAny []
+
+            wrongScript =
+                ScriptAll []
+
+            utxoBeingSpent =
+                makeRef "previouslySentToLock" 0
+
+            utxoWithScriptRef =
+                makeRef "scriptRef" 0
+
+            localStateUtxos =
+                [ makeAdaOutput 0 testAddr.me 5
+                , ( utxoBeingSpent
+                  , { address = Address.script Mainnet (Script.hash <| Script.Native correctScript)
+                    , amount = Value.onlyLovelace (ada 4)
+                    , datumOption = Nothing
+                    , referenceScript = Nothing
+                    }
+                  )
+                , ( utxoWithScriptRef
+                  , { address = testAddr.me
+                    , amount = Value.onlyLovelace (ada 2)
+                    , datumOption = Nothing
+                    , referenceScript = Just <| Script.refFromScript <| Script.Native wrongScript
+                    }
+                  )
+                ]
+          in
+          failTxTest "when providing the wrong native script witness by reference"
+            { govState = Cardano.emptyGovernanceState
+            , localStateUtxos = localStateUtxos
+            , evalScriptsCosts = \_ _ -> Ok []
+            , fee = twoAdaFee
+            , txOtherInfo = []
+            , txIntents =
+                [ Spend <|
+                    FromNativeScript
+                        { spentInput = utxoBeingSpent
+                        , nativeScriptWitness = WitnessByReference utxoWithScriptRef
+                        }
+                , SendTo testAddr.me (Value.onlyLovelace <| ada 4)
+                ]
+            }
+            (\error ->
+                case error of
+                    ScriptHashMismatch _ _ ->
+                        Expect.pass
+
+                    _ ->
+                        Expect.fail ("I didn’t expect this failure: " ++ Debug.toString error)
+            )
+
+        -- Test failing when providing a witness by reference with no reference script
+        , let
+            utxoBeingSpent =
+                makeRef "previouslySentToLock" 0
+
+            utxoWithoutScriptRef =
+                makeRef "scriptRef" 0
+
+            localStateUtxos =
+                [ makeAdaOutput 0 testAddr.me 5
+                , ( utxoBeingSpent
+                  , { address = Address.script Mainnet (Script.hash <| Script.Native <| ScriptAny [])
+                    , amount = Value.onlyLovelace (ada 4)
+                    , datumOption = Nothing
+                    , referenceScript = Nothing
+                    }
+                  )
+                , ( utxoWithoutScriptRef
+                  , { address = testAddr.me
+                    , amount = Value.onlyLovelace (ada 2)
+                    , datumOption = Nothing
+                    , referenceScript = Nothing
+                    }
+                  )
+                ]
+          in
+          failTxTest "when providing a witness by reference with no reference script"
+            { govState = Cardano.emptyGovernanceState
+            , localStateUtxos = localStateUtxos
+            , evalScriptsCosts = \_ _ -> Ok []
+            , fee = twoAdaFee
+            , txOtherInfo = []
+            , txIntents =
+                [ Spend <|
+                    FromNativeScript
+                        { spentInput = utxoBeingSpent
+                        , nativeScriptWitness = WitnessByReference utxoWithoutScriptRef
+                        }
+                , SendTo testAddr.me (Value.onlyLovelace <| ada 4)
+                ]
+            }
+            (\error ->
+                case error of
+                    MissingReferenceScript _ ->
+                        Expect.pass
+
+                    _ ->
+                        Expect.fail ("I didn’t expect this failure: " ++ Debug.toString error)
+            )
+
+        -- Test that provided plutus script witness value has the expected hash
+        , let
+            correctScript =
+                Script.plutusScriptFromBytes PlutusV3 <| Bytes.fromHexUnchecked ""
+
+            wrongScript =
+                ( PlutusV2, WitnessByValue <| Bytes.fromHexUnchecked "" )
+
+            utxoBeingSpent =
+                makeRef "previouslySentToLock" 0
+
+            localStateUtxos =
+                [ makeAdaOutput 0 testAddr.me 5
+                , ( utxoBeingSpent
+                  , { address = Address.script Mainnet (Script.hash <| Script.Plutus correctScript)
+                    , amount = Value.onlyLovelace <| ada 4
+                    , datumOption = Nothing
+                    , referenceScript = Nothing
+                    }
+                  )
+                ]
+          in
+          failTxTest "when providing the wrong plutus script witness"
+            { govState = Cardano.emptyGovernanceState
+            , localStateUtxos = localStateUtxos
+            , evalScriptsCosts = \_ _ -> Ok []
+            , fee = twoAdaFee
+            , txOtherInfo = []
+            , txIntents =
+                [ Spend <|
+                    FromPlutusScript
+                        { spentInput = utxoBeingSpent
+                        , datumWitness = Nothing
+                        , plutusScriptWitness =
+                            { script = wrongScript
+                            , redeemerData = \_ -> Data.List []
+                            , requiredSigners = []
+                            }
+                        }
+                , SendTo testAddr.me (Value.onlyLovelace <| ada 4)
+                ]
+            }
+            (\error ->
+                case error of
+                    ScriptHashMismatch _ _ ->
+                        Expect.pass
+
+                    _ ->
+                        Expect.fail ("I didn’t expect this failure: " ++ Debug.toString error)
+            )
+
+        -- Test that there is no extraneous datum witness
+        , let
+            script =
+                Script.plutusScriptFromBytes PlutusV3 <| Bytes.fromHexUnchecked ""
+
+            scriptWitness =
+                ( PlutusV3, WitnessByValue <| Bytes.fromHexUnchecked "" )
+
+            extraneousDatumWitness =
+                WitnessByValue <| Data.List []
+
+            utxoBeingSpent =
+                makeRef "previouslySentToLock" 0
+
+            localStateUtxos =
+                [ makeAdaOutput 0 testAddr.me 5
+                , ( utxoBeingSpent
+                  , { address = Address.script Mainnet (Script.hash <| Script.Plutus script)
+                    , amount = Value.onlyLovelace <| ada 4
+
+                    -- No datum at the script utxo
+                    , datumOption = Nothing
+                    , referenceScript = Nothing
+                    }
+                  )
+                ]
+          in
+          failTxTest "when there is an extraneous datum witness (no datum at script utxo)"
+            { govState = Cardano.emptyGovernanceState
+            , localStateUtxos = localStateUtxos
+            , evalScriptsCosts = \_ _ -> Ok []
+            , fee = twoAdaFee
+            , txOtherInfo = []
+            , txIntents =
+                [ Spend <|
+                    FromPlutusScript
+                        { spentInput = utxoBeingSpent
+
+                        -- Extraneous datum witness here
+                        , datumWitness = Just extraneousDatumWitness
+                        , plutusScriptWitness =
+                            { script = scriptWitness
+                            , redeemerData = \_ -> Data.List []
+                            , requiredSigners = []
+                            }
+                        }
+                , SendTo testAddr.me (Value.onlyLovelace <| ada 4)
+                ]
+            }
+            (\error ->
+                case error of
+                    ExtraneousDatumWitness _ _ ->
+                        Expect.pass
+
+                    _ ->
+                        Expect.fail ("I didn’t expect this failure: " ++ Debug.toString error)
+            )
+
+        -- Test that there is no extraneous datum witness (already by value in script utxo)
+        , let
+            script =
+                Script.plutusScriptFromBytes PlutusV3 <| Bytes.fromHexUnchecked ""
+
+            scriptWitness =
+                ( PlutusV3, WitnessByValue <| Bytes.fromHexUnchecked "" )
+
+            extraneousDatumWitness =
+                WitnessByValue <| Data.List []
+
+            utxoBeingSpent =
+                makeRef "previouslySentToLock" 0
+
+            localStateUtxos =
+                [ makeAdaOutput 0 testAddr.me 5
+                , ( utxoBeingSpent
+                  , { address = Address.script Mainnet (Script.hash <| Script.Plutus script)
+                    , amount = Value.onlyLovelace <| ada 4
+
+                    -- Datum already provided by value
+                    , datumOption = Just <| DatumValue <| Data.List []
+                    , referenceScript = Nothing
+                    }
+                  )
+                ]
+          in
+          failTxTest "when there is an extraneous datum witness (datum value already at script utxo)"
+            { govState = Cardano.emptyGovernanceState
+            , localStateUtxos = localStateUtxos
+            , evalScriptsCosts = \_ _ -> Ok []
+            , fee = twoAdaFee
+            , txOtherInfo = []
+            , txIntents =
+                [ Spend <|
+                    FromPlutusScript
+                        { spentInput = utxoBeingSpent
+
+                        -- Extraneous datum witness here
+                        , datumWitness = Just extraneousDatumWitness
+                        , plutusScriptWitness =
+                            { script = scriptWitness
+                            , redeemerData = \_ -> Data.List []
+                            , requiredSigners = []
+                            }
+                        }
+                , SendTo testAddr.me (Value.onlyLovelace <| ada 4)
+                ]
+            }
+            (\error ->
+                case error of
+                    ExtraneousDatumWitness _ _ ->
+                        Expect.pass
+
+                    _ ->
+                        Expect.fail ("I didn’t expect this failure: " ++ Debug.toString error)
+            )
+
+        -- Test that the datum witness is not missing
+        , let
+            script =
+                Script.plutusScriptFromBytes PlutusV3 <| Bytes.fromHexUnchecked ""
+
+            scriptWitness =
+                ( PlutusV3, WitnessByValue <| Bytes.fromHexUnchecked "" )
+
+            utxoBeingSpent =
+                makeRef "previouslySentToLock" 0
+
+            datum =
+                Data.List []
+
+            localStateUtxos =
+                [ makeAdaOutput 0 testAddr.me 5
+                , ( utxoBeingSpent
+                  , { address = Address.script Mainnet (Script.hash <| Script.Plutus script)
+                    , amount = Value.onlyLovelace <| ada 4
+
+                    -- Datum provided by hash
+                    , datumOption = Just <| DatumHash <| Data.hash datum
+                    , referenceScript = Nothing
+                    }
+                  )
+                ]
+          in
+          failTxTest "when the datum witness is missing"
+            { govState = Cardano.emptyGovernanceState
+            , localStateUtxos = localStateUtxos
+            , evalScriptsCosts = \_ _ -> Ok []
+            , fee = twoAdaFee
+            , txOtherInfo = []
+            , txIntents =
+                [ Spend <|
+                    FromPlutusScript
+                        { spentInput = utxoBeingSpent
+                        , datumWitness = Nothing
+                        , plutusScriptWitness =
+                            { script = scriptWitness
+                            , redeemerData = \_ -> Data.List []
+                            , requiredSigners = []
+                            }
+                        }
+                , SendTo testAddr.me (Value.onlyLovelace <| ada 4)
+                ]
+            }
+            (\error ->
+                case error of
+                    MissingDatumWitness _ _ ->
+                        Expect.pass
+
+                    _ ->
+                        Expect.fail ("I didn’t expect this failure: " ++ Debug.toString error)
+            )
+
+        -- Test that the datum witness is not missing (by ref)
+        , let
+            script =
+                Script.plutusScriptFromBytes PlutusV3 <| Bytes.fromHexUnchecked ""
+
+            scriptWitness =
+                ( PlutusV3, WitnessByValue <| Bytes.fromHexUnchecked "" )
+
+            utxoBeingSpent =
+                makeRef "previouslySentToLock" 0
+
+            utxoRefWithoutDatum =
+                makeRef "datumRef" 0
+
+            datum =
+                Data.List []
+
+            localStateUtxos =
+                [ makeAdaOutput 0 testAddr.me 5
+                , ( utxoBeingSpent
+                  , { address = Address.script Mainnet (Script.hash <| Script.Plutus script)
+                    , amount = Value.onlyLovelace <| ada 4
+
+                    -- Datum provided by hash
+                    , datumOption = Just <| DatumHash <| Data.hash datum
+                    , referenceScript = Nothing
+                    }
+                  )
+                , ( utxoRefWithoutDatum
+                  , { address = Address.script Mainnet (Script.hash <| Script.Plutus script)
+                    , amount = Value.onlyLovelace <| ada 4
+                    , datumOption = Nothing
+                    , referenceScript = Nothing
+                    }
+                  )
+                ]
+          in
+          failTxTest "when the datum witness is missing (by ref)"
+            { govState = Cardano.emptyGovernanceState
+            , localStateUtxos = localStateUtxos
+            , evalScriptsCosts = \_ _ -> Ok []
+            , fee = twoAdaFee
+            , txOtherInfo = []
+            , txIntents =
+                [ Spend <|
+                    FromPlutusScript
+                        { spentInput = utxoBeingSpent
+                        , datumWitness = Just <| WitnessByReference utxoRefWithoutDatum
+                        , plutusScriptWitness =
+                            { script = scriptWitness
+                            , redeemerData = \_ -> Data.List []
+                            , requiredSigners = []
+                            }
+                        }
+                , SendTo testAddr.me (Value.onlyLovelace <| ada 4)
+                ]
+            }
+            (\error ->
+                case error of
+                    MissingDatumWitness _ _ ->
+                        Expect.pass
+
+                    _ ->
+                        Expect.fail ("I didn’t expect this failure: " ++ Debug.toString error)
+            )
+
+        -- Test that the datum witness is matching (by value)
+        , let
+            script =
+                Script.plutusScriptFromBytes PlutusV3 <| Bytes.fromHexUnchecked ""
+
+            scriptWitness =
+                ( PlutusV3, WitnessByValue <| Bytes.fromHexUnchecked "" )
+
+            utxoBeingSpent =
+                makeRef "previouslySentToLock" 0
+
+            correctDatum =
+                Data.List []
+
+            wrongDatum =
+                Data.List [ Data.List [] ]
+
+            localStateUtxos =
+                [ makeAdaOutput 0 testAddr.me 5
+                , ( utxoBeingSpent
+                  , { address = Address.script Mainnet (Script.hash <| Script.Plutus script)
+                    , amount = Value.onlyLovelace <| ada 4
+
+                    -- Datum provided by hash
+                    , datumOption = Just <| DatumHash <| Data.hash correctDatum
+                    , referenceScript = Nothing
+                    }
+                  )
+                ]
+          in
+          failTxTest "when the datum witness is not matching (by value)"
+            { govState = Cardano.emptyGovernanceState
+            , localStateUtxos = localStateUtxos
+            , evalScriptsCosts = \_ _ -> Ok []
+            , fee = twoAdaFee
+            , txOtherInfo = []
+            , txIntents =
+                [ Spend <|
+                    FromPlutusScript
+                        { spentInput = utxoBeingSpent
+                        , datumWitness = Just <| WitnessByValue wrongDatum
+                        , plutusScriptWitness =
+                            { script = scriptWitness
+                            , redeemerData = \_ -> Data.List []
+                            , requiredSigners = []
+                            }
+                        }
+                , SendTo testAddr.me (Value.onlyLovelace <| ada 4)
+                ]
+            }
+            (\error ->
+                case error of
+                    DatumHashMismatch _ _ ->
+                        Expect.pass
+
+                    _ ->
+                        Expect.fail ("I didn’t expect this failure: " ++ Debug.toString error)
+            )
+
+        -- Test that the datum witness is matching (by ref)
+        , let
+            script =
+                Script.plutusScriptFromBytes PlutusV3 <| Bytes.fromHexUnchecked ""
+
+            scriptWitness =
+                ( PlutusV3, WitnessByValue <| Bytes.fromHexUnchecked "" )
+
+            utxoBeingSpent =
+                makeRef "previouslySentToLock" 0
+
+            utxoRef =
+                makeRef "datumRef" 0
+
+            correctDatum =
+                Data.List []
+
+            wrongDatum =
+                Data.List [ Data.List [] ]
+
+            localStateUtxos =
+                [ makeAdaOutput 0 testAddr.me 5
+                , ( utxoBeingSpent
+                  , { address = Address.script Mainnet (Script.hash <| Script.Plutus script)
+                    , amount = Value.onlyLovelace <| ada 4
+
+                    -- Datum provided by hash
+                    , datumOption = Just <| DatumHash <| Data.hash correctDatum
+                    , referenceScript = Nothing
+                    }
+                  )
+                , ( utxoRef
+                  , { address = Address.script Mainnet (Script.hash <| Script.Plutus script)
+                    , amount = Value.onlyLovelace <| ada 4
+                    , datumOption = Just <| DatumValue wrongDatum
+                    , referenceScript = Nothing
+                    }
+                  )
+                ]
+          in
+          failTxTest "when the datum witness is not matching (by ref)"
+            { govState = Cardano.emptyGovernanceState
+            , localStateUtxos = localStateUtxos
+            , evalScriptsCosts = \_ _ -> Ok []
+            , fee = twoAdaFee
+            , txOtherInfo = []
+            , txIntents =
+                [ Spend <|
+                    FromPlutusScript
+                        { spentInput = utxoBeingSpent
+                        , datumWitness = Just <| WitnessByReference utxoRef
+                        , plutusScriptWitness =
+                            { script = scriptWitness
+                            , redeemerData = \_ -> Data.List []
+                            , requiredSigners = []
+                            }
+                        }
+                , SendTo testAddr.me (Value.onlyLovelace <| ada 4)
+                ]
+            }
+            (\error ->
+                case error of
+                    DatumHashMismatch _ _ ->
                         Expect.pass
 
                     _ ->


### PR DESCRIPTION
This PR adds many witness checks in the finalization step of Tx building as well as tests for these. Some of these checks are:
- check that spent addresses match the type of spending intent (wallet / script)
- check that script witnesses are valid (hash matches, etc.)
- check that datum witnesses are valid (hash matches, etc.)