### PR TITLE
Also provide expected signers for spending native scripts

### DIFF
--- a/tests/Cardano/TxBuilding.elm
+++ b/tests/Cardano/TxBuilding.elm
@@ -1172,7 +1172,10 @@ failTxBuilding =
                 [ Spend <|
                     FromNativeScript
                         { spentInput = utxoBeingSpent
-                        , nativeScriptWitness = WitnessByValue wrongScript
+                        , nativeScriptWitness =
+                            { script = WitnessByValue wrongScript
+                            , expectedSigners = []
+                            }
                         }
                 , SendTo testAddr.me (Value.onlyLovelace <| ada 4)
                 ]
@@ -1228,7 +1231,10 @@ failTxBuilding =
                 [ Spend <|
                     FromNativeScript
                         { spentInput = utxoBeingSpent
-                        , nativeScriptWitness = WitnessByReference utxoWithScriptRef
+                        , nativeScriptWitness =
+                            { script = WitnessByReference utxoWithScriptRef
+                            , expectedSigners = []
+                            }
                         }
                 , SendTo testAddr.me (Value.onlyLovelace <| ada 4)
                 ]
@@ -1278,7 +1284,10 @@ failTxBuilding =
                 [ Spend <|
                     FromNativeScript
                         { spentInput = utxoBeingSpent
-                        , nativeScriptWitness = WitnessByReference utxoWithoutScriptRef
+                        , nativeScriptWitness =
+                            { script = WitnessByReference utxoWithoutScriptRef
+                            , expectedSigners = []
+                            }
                         }
                 , SendTo testAddr.me (Value.onlyLovelace <| ada 4)
                 ]


### PR DESCRIPTION
Previously, we only needed to provide the witness source for spending UTxOs at a native script address. Now we also need to provide expected signers.

Otherwise we don’t know who is gonna sign a multisig (all? none? some?). And we need the correct list of signers to correctly estimate the Tx fees.