### PR TITLE
Modularize coin selection computation

### DIFF
--- a/src/Cardano.elm
+++ b/src/Cardano.elm
@@ -1134,7 +1134,9 @@ finalizeAdvanced { govState, localStateUtxos, coinSelectionAlgo, evalScriptsCost
                                 |> buildTx feeAmount collateralSelection processedIntents processedOtherInfo
                         )
                         (computeCoinSelection localStateUtxos roundFees processedIntents coinSelectionAlgo)
-                        (computeCollateralSelection localStateUtxos collateralSources collateralAmount)
+                        (CoinSelection.collateral localStateUtxos collateralSources collateralAmount
+                            |> Result.mapError CollateralSelectionError
+                        )
 
                 computeRefScriptBytesForTx tx =
                     computeRefScriptBytes localStateUtxos (tx.body.referenceInputs ++ tx.body.inputs)
@@ -2324,131 +2326,6 @@ processOtherInfo otherInfo =
 
     else
         Ok processedOtherInfo
-
-
-{-| Perform collateral selection.
-
-Only UTxOs at the provided whitelist of addresses are viable.
-UTxOs are picked following a prioritization list.
-
-  - First, prioritize UTxOs with only Ada in them,
-    and with >= ? Ada, but lowest amounts prioritized over higher amounts.
-  - Second, prioritize UTxOs with >= ? Ada, and that would cost minimal fees to add,
-    so basically no reference script, no datums, and minimal number of assets.
-  - Third, everything else, prioritized with >= ? Ada first,
-    and sorted by minimal fee cost associated.
-  - Finally, all the rest, sorted by "available" ada amounts (without min Ada),
-    with bigger available amounts prioritized over smaller amounts.
-
--}
-computeCollateralSelection :
-    Utxo.RefDict Output
-    -> Address.Dict ()
-    -> Natural
-    -> Result TxFinalizationError CoinSelection.Selection
-computeCollateralSelection localStateUtxos collateralSources collateralAmount =
-    let
-        -- TODO: max inputs should come from a network parameter
-        maxInputCount =
-            3
-
-        utxosInAllowedAddresses : List ( OutputReference, Output )
-        utxosInAllowedAddresses =
-            Dict.Any.toList localStateUtxos
-                |> List.filter
-                    (\( _, output ) -> Dict.Any.member output.address collateralSources)
-
-        ( adaOnly, notAdaOnly ) =
-            List.partition (\( _, output ) -> Utxo.isAdaOnly output)
-                utxosInAllowedAddresses
-
-        ( assetsOnly, notAssetsOnly ) =
-            List.partition (\( _, output ) -> Utxo.isAssetsOnly output)
-                notAdaOnly
-
-        -- Some threshold to guarantee that after collateral is spent,
-        -- there is still enough for an ada-only output (approximated at 1 ada)
-        adaOnlyThreshold =
-            Natural.add collateralAmount (Natural.fromSafeInt 1000000)
-
-        -- Helper function to convert the lovelace amount in an output into
-        -- a comparable value, safe from JS float overflow.
-        -- By removing 5 decimals, we are guaranteed to have amounts
-        -- lower than 450B (45B ada total supply), which is way below JS max safe integer around 2^53
-        adaComparableAmount : Natural -> Float
-        adaComparableAmount lovelace =
-            lovelace
-                |> Natural.divBy (Natural.fromSafeInt 100000)
-                |> Maybe.withDefault Natural.zero
-                |> Natural.toInt
-                |> toFloat
-
-        -- First, prioritize UTxOs with only Ada in them,
-        -- and with >= ? Ada, but lowest amounts prioritized over higher amounts.
-        ( highAdaOnly, lowAdaOnly ) =
-            List.partition
-                (\( _, { amount } ) -> amount.lovelace |> Natural.isGreaterThan adaOnlyThreshold)
-                adaOnly
-
-        highAdaOnlyCount =
-            List.length highAdaOnly
-
-        highAdaOnlySorted =
-            List.sortBy (\( _, { amount } ) -> adaComparableAmount amount.lovelace) highAdaOnly
-
-        availableUtxos =
-            if highAdaOnlyCount >= maxInputCount then
-                highAdaOnlySorted
-
-            else
-                -- Second, prioritize UTxOs with >= ? Ada, and that would cost minimal fees to add,
-                -- so basically no reference script, no datums, and minimal number of assets.
-                let
-                    -- Add another ada for priority UTxOs with other tokens
-                    assetOnlyThreshold =
-                        Natural.add adaOnlyThreshold (Natural.fromSafeInt 1000000)
-
-                    ( highAssetsOnly, lowAssetsOnly ) =
-                        List.partition
-                            (\( _, { amount } ) -> amount.lovelace |> Natural.isGreaterThan assetOnlyThreshold)
-                            assetsOnly
-
-                    highAssetsOnlyCount =
-                        List.length highAssetsOnly
-
-                    highAssetsOnlySorted =
-                        List.sortBy (Tuple.second >> Utxo.bytesWidth) highAssetsOnly
-                in
-                if highAdaOnlyCount + highAssetsOnlyCount >= maxInputCount then
-                    List.concat [ highAdaOnlySorted, highAssetsOnlySorted ]
-
-                else
-                    -- Third, everything else, prioritized with >= ? Ada first,
-                    -- and sorted by minimal fee cost associated.
-                    -- Finally, all the rest, sorted by "available" ada amounts (without min Ada),
-                    -- with bigger available amounts prioritized over smaller amounts.
-                    --
-                    -- TODO: Improve, but honestly it’s very low priority,
-                    -- so for now we just sort the rest by free ada (after removing min Ada).
-                    let
-                        freeAdaComparable : Output -> Float
-                        freeAdaComparable output =
-                            adaComparableAmount (Utxo.freeAda output)
-
-                        allOtherUtxos =
-                            List.concat [ lowAdaOnly, lowAssetsOnly, notAssetsOnly ]
-
-                        allOtherUtxosSorted =
-                            List.sortBy (Tuple.second >> freeAdaComparable) allOtherUtxos
-                    in
-                    List.concat [ highAdaOnlySorted, highAssetsOnlySorted, allOtherUtxosSorted ]
-    in
-    CoinSelection.inOrderedList maxInputCount
-        { alreadySelectedUtxos = []
-        , targetAmount = Value.onlyLovelace collateralAmount
-        , availableUtxos = availableUtxos
-        }
-        |> Result.mapError CollateralSelectionError
 
 
 {-| Perform coin selection for the required input per address.

--- a/src/Cardano/CoinSelection.elm
+++ b/src/Cardano/CoinSelection.elm
@@ -26,13 +26,13 @@ selection algorithm as described in CIP2 (<https://cips.cardano.org/cips/cip2/>)
 @docs perAddress, PerAddressConfig, PerAddressContext
 
 
-# Collateral
+# Collateral Selection
 
 @docs CollateralContext, collateral
 
 -}
 
-import Bytes.Comparable as Bytes exposing (Bytes)
+import Bytes.Comparable exposing (Bytes)
 import Cardano.Address as Address exposing (Address)
 import Cardano.MultiAsset as MultiAsset exposing (AssetName, PolicyId)
 import Cardano.Utxo as Utxo exposing (Output, OutputReference)


### PR DESCRIPTION
This change modularize both the builder coin selection algorithm and the collateral selection algorithm in ways that make them very easily customizable. So follow up PRs could easily improve the coin selection algorithm, with control over change split and input/output simplifications.