### PR TITLE
Add Certificate Intents for Combined Registration and Delegation

### DIFF
--- a/src/Cardano/Gov.elm
+++ b/src/Cardano/Gov.elm
@@ -656,8 +656,8 @@ decodeProtocolParamUpdate =
             >> D.optionalField 31 D.natural
             -- drepActivity : Maybe Natural -- 32
             >> D.optionalField 32 D.natural
-            -- minFeeRefScriptCostPerByte : Maybe RationalNumber -- 33
-            >> D.optionalField 33 decodeRational
+            -- minFeeRefScriptCostPerByte : Maybe Int -- 33
+            >> D.optionalField 33 D.int
 
 
 {-| Decoder for PoolVotingThresholds type.
@@ -742,7 +742,7 @@ type alias ProtocolParamUpdate =
     , governanceActionDeposit : Maybe Natural -- 30
     , drepDeposit : Maybe Natural -- 31
     , drepInactivityPeriod : Maybe Natural -- 32
-    , minFeeRefScriptCostPerByte : Maybe RationalNumber -- 33
+    , minFeeRefScriptCostPerByte : Maybe Int -- 33
     }
 
 
@@ -1048,7 +1048,7 @@ encodeProtocolParamUpdate =
             >> E.optionalField 30 EE.natural .governanceActionDeposit
             >> E.optionalField 31 EE.natural .drepDeposit
             >> E.optionalField 32 EE.natural .drepInactivityPeriod
-            >> E.optionalField 33 encodeRationalNumber .minFeeRefScriptCostPerByte
+            >> E.optionalField 33 E.int .minFeeRefScriptCostPerByte
 
 
 {-| Encoder for Voter type.

--- a/src/Cardano/Gov.elm
+++ b/src/Cardano/Gov.elm
@@ -656,8 +656,8 @@ decodeProtocolParamUpdate =
             >> D.optionalField 31 D.natural
             -- drepActivity : Maybe Natural -- 32
             >> D.optionalField 32 D.natural
-            -- minFeeRefScriptCostPerByte : Maybe Int -- 33
-            >> D.optionalField 33 D.int
+            -- minFeeRefScriptCostPerByte : Maybe RationalNumber -- 33
+            >> D.optionalField 33 decodeRational
 
 
 {-| Decoder for PoolVotingThresholds type.
@@ -742,7 +742,7 @@ type alias ProtocolParamUpdate =
     , governanceActionDeposit : Maybe Natural -- 30
     , drepDeposit : Maybe Natural -- 31
     , drepInactivityPeriod : Maybe Natural -- 32
-    , minFeeRefScriptCostPerByte : Maybe Int -- 33
+    , minFeeRefScriptCostPerByte : Maybe RationalNumber -- 33
     }
 
 
@@ -881,10 +881,10 @@ encodeDrep drep =
             Address.credentialToCbor cred
 
         AlwaysAbstain ->
-            E.int 2
+            E.list E.int [ 2 ]
 
         AlwaysNoConfidence ->
-            E.int 3
+            E.list E.int [ 3 ]
 
 
 {-| Encoder for Anchor type.
@@ -1048,7 +1048,7 @@ encodeProtocolParamUpdate =
             >> E.optionalField 30 EE.natural .governanceActionDeposit
             >> E.optionalField 31 EE.natural .drepDeposit
             >> E.optionalField 32 EE.natural .drepInactivityPeriod
-            >> E.optionalField 33 E.int .minFeeRefScriptCostPerByte
+            >> E.optionalField 33 encodeRationalNumber .minFeeRefScriptCostPerByte
 
 
 {-| Encoder for Voter type.

--- a/src/Cardano/TxIntent.elm
+++ b/src/Cardano/TxIntent.elm
@@ -135,6 +135,7 @@ type CertificateIntent
     = RegisterStake { delegator : Witness.Credential, deposit : Natural }
     | UnregisterStake { delegator : Witness.Credential, refund : Natural }
     | DelegateStake { delegator : Witness.Credential, poolId : Bytes Pool.Id }
+    | RegisterAndDelegateStake { delegator : Witness.Credential, poolId : Bytes Pool.Id, deposit : Natural }
       -- Pool management
     | RegisterPool { deposit : Natural } Pool.Params
     | RetirePool { poolId : Bytes Pool.Id, epoch : Natural }
@@ -674,6 +675,13 @@ containPlutusScripts txIntents =
             else
                 containPlutusScripts otherIntents
 
+        (IssueCertificate (RegisterAndDelegateStake { delegator })) :: otherIntents ->
+            if Witness.credentialIsPlutusScript delegator then
+                True
+
+            else
+                containPlutusScripts otherIntents
+
         (IssueCertificate (RegisterPool _ _)) :: otherIntents ->
             containPlutusScripts otherIntents
 
@@ -1169,6 +1177,14 @@ preProcessIntents txIntents =
                         (\keyCred -> StakeDelegationCert { delegator = VKeyHash keyCred, poolId = poolId })
                         (\scriptHash -> StakeDelegationCert { delegator = ScriptHash scriptHash, poolId = poolId })
                         { deposit = Natural.zero, refund = Natural.zero }
+                        delegator
+                        preProcessedIntents
+
+                IssueCertificate (RegisterAndDelegateStake { delegator, poolId, deposit }) ->
+                    preprocessCert
+                        (\keyCred -> StakeRegDelegCert { delegator = VKeyHash keyCred, poolId = poolId, deposit = deposit })
+                        (\scriptHash -> StakeRegDelegCert { delegator = ScriptHash scriptHash, poolId = poolId, deposit = deposit })
+                        { deposit = deposit, refund = Natural.zero }
                         delegator
                         preProcessedIntents
 

--- a/src/Cardano/TxIntent.elm
+++ b/src/Cardano/TxIntent.elm
@@ -144,6 +144,8 @@ type CertificateIntent
     | VoteAlwaysAbstain { delegator : Witness.Credential }
     | VoteAlwaysNoConfidence { delegator : Witness.Credential }
     | DelegateVotes { delegator : Witness.Credential, drep : Credential }
+    | RegisterAndDelegateVotes { delegator : Witness.Credential, drep : Gov.Drep, deposit : Natural }
+    | RegisterAndDelegateStakeAndVotes { delegator : Witness.Credential, poolId : Bytes Pool.Id, drep : Gov.Drep, deposit : Natural }
 
 
 {-| Governance vote.
@@ -715,6 +717,20 @@ containPlutusScripts txIntents =
             else
                 containPlutusScripts otherIntents
 
+        (IssueCertificate (RegisterAndDelegateVotes { delegator })) :: otherIntents ->
+            if Witness.credentialIsPlutusScript delegator then
+                True
+
+            else
+                containPlutusScripts otherIntents
+
+        (IssueCertificate (RegisterAndDelegateStakeAndVotes { delegator })) :: otherIntents ->
+            if Witness.credentialIsPlutusScript delegator then
+                True
+
+            else
+                containPlutusScripts otherIntents
+
         (WithdrawRewards { scriptWitness }) :: otherIntents ->
             case scriptWitness of
                 Just (Witness.Plutus _) ->
@@ -1209,6 +1225,22 @@ preProcessIntents txIntents =
                         (\keyCred -> VoteDelegCert { delegator = VKeyHash keyCred, drep = DrepCredential drep })
                         (\scriptHash -> VoteDelegCert { delegator = ScriptHash scriptHash, drep = DrepCredential drep })
                         { deposit = Natural.zero, refund = Natural.zero }
+                        delegator
+                        preProcessedIntents
+
+                IssueCertificate (RegisterAndDelegateVotes { delegator, drep, deposit }) ->
+                    preprocessCert
+                        (\keyCred -> VoteRegDelegCert { delegator = VKeyHash keyCred, drep = drep, deposit = deposit })
+                        (\scriptHash -> VoteRegDelegCert { delegator = ScriptHash scriptHash, drep = drep, deposit = deposit })
+                        { deposit = deposit, refund = Natural.zero }
+                        delegator
+                        preProcessedIntents
+
+                IssueCertificate (RegisterAndDelegateStakeAndVotes { delegator, poolId, drep, deposit }) ->
+                    preprocessCert
+                        (\keyCred -> StakeVoteRegDelegCert { delegator = VKeyHash keyCred, poolId = poolId, drep = drep, deposit = deposit })
+                        (\scriptHash -> StakeVoteRegDelegCert { delegator = ScriptHash scriptHash, poolId = poolId, drep = drep, deposit = deposit })
+                        { deposit = deposit, refund = Natural.zero }
                         delegator
                         preProcessedIntents
 

--- a/tests/Cardano/GovTests.elm
+++ b/tests/Cardano/GovTests.elm
@@ -3,6 +3,7 @@ module Cardano.GovTests exposing (suite)
 import Bytes.Comparable as Bytes
 import Cardano.Address exposing (Credential(..))
 import Cardano.Gov as Gov
+import Cbor.Encode as E
 import Expect exposing (Expectation)
 import Test exposing (Test, describe, test)
 
@@ -26,6 +27,22 @@ suite =
             , test "Cc hot" ccHotBech32EncodingTest
             , test "Cc cold" ccColdBech32EncodingTest
             , test "DRep" drepBech32EncodingTest
+            ]
+        , describe "DRep CBOR encoding"
+            [ test "AlwaysAbstain uses a single-element array" <|
+                \_ ->
+                    Gov.encodeDrep Gov.AlwaysAbstain
+                        |> E.encode
+                        |> Bytes.fromBytes
+                        |> Bytes.toHex
+                        |> Expect.equal "8102"
+            , test "AlwaysNoConfidence uses a single-element array" <|
+                \_ ->
+                    Gov.encodeDrep Gov.AlwaysNoConfidence
+                        |> E.encode
+                        |> Bytes.fromBytes
+                        |> Bytes.toHex
+                        |> Expect.equal "8103"
             ]
         ]
 

--- a/tests/Cardano/TxBuilding.elm
+++ b/tests/Cardano/TxBuilding.elm
@@ -524,6 +524,79 @@ okTxBuilding =
                 }
             )
 
+        -- Test with stake registration and pool delegation in a single certificate
+        , let
+            myStakeKeyHash =
+                Address.extractStakeKeyHash testAddr.me
+                    |> Maybe.withDefault (dummyCredentialHash "ERROR")
+          in
+          okTxTest "Test with combined stake registration and pool delegation"
+            { govState = TxIntent.emptyGovernanceState
+            , localStateUtxos = [ makeAdaOutput 0 testAddr.me 5 ]
+            , evalScriptsCosts = \_ _ -> Ok []
+            , fee = twoAdaFee
+            , txOtherInfo = []
+            , txIntents =
+                [ Spend <|
+                    FromWallet
+                        { address = testAddr.me
+                        , value = Value.onlyLovelace (ada 2) -- 2 ada for the registration deposit
+                        , guaranteedUtxos = []
+                        }
+                , IssueCertificate <|
+                    RegisterAndDelegateStake
+                        { delegator = WithKey myStakeKeyHash
+                        , poolId = Bytes.dummy 28 "poolId"
+                        , deposit = ada 2
+                        }
+                ]
+            }
+            (\_ ->
+                { tx =
+                    { newTx
+                        | body =
+                            { newBody
+                                | fee = ada 2
+                                , inputs = [ makeRef "0" 0 ]
+                                , outputs = [ Utxo.fromLovelace testAddr.me (ada 1) ]
+                                , certificates =
+                                    [ StakeRegDelegCert
+                                        { delegator = VKeyHash myStakeKeyHash
+                                        , poolId = Bytes.dummy 28 "poolId"
+                                        , deposit = Natural.fromSafeInt 2000000
+                                        }
+                                    ]
+                            }
+                    }
+                , expectedSignatures =
+                    [ dummyCredentialHash "key-me"
+                    , dummyCredentialHash "stk-me"
+                    ]
+                }
+            )
+        , okTxTest "builds combined stake registration and delegation with a Plutus credential"
+            { govState = TxIntent.emptyGovernanceState
+            , localStateUtxos = [ makeAdaOutput 0 testAddr.me 5 ]
+            , evalScriptsCosts = Uplc.evalScriptsCosts Uplc.defaultVmConfig
+            , fee = twoAdaFee
+            , txOtherInfo = []
+            , txIntents =
+                [ IssueCertificate <|
+                    RegisterAndDelegateStake
+                        { delegator =
+                            WithScript indexedScript.hash <|
+                                Witness.Plutus (indexedScript.witness 0)
+                        , poolId = Bytes.dummy 28 "poolId"
+                        , deposit = Natural.zero
+                        }
+                ]
+            }
+            (\{ tx } ->
+                { tx = tx
+                , expectedSignatures = [ dummyCredentialHash "key-me" ]
+                }
+            )
+
         -- Test with 6 different proposals
         , let
             myStakeKeyHash =

--- a/tests/Cardano/TxBuilding.elm
+++ b/tests/Cardano/TxBuilding.elm
@@ -8,7 +8,7 @@ import Cardano.Data as Data
 import Cardano.Gov as Gov exposing (Drep(..), Vote(..), Voter(..), noParamUpdate)
 import Cardano.Metadatum as Metadatum
 import Cardano.MultiAsset as MultiAsset exposing (PolicyId)
-import Cardano.Redeemer exposing (Redeemer)
+import Cardano.Redeemer as Redeemer exposing (Redeemer)
 import Cardano.Script as Script exposing (NativeScript(..), PlutusVersion(..))
 import Cardano.Transaction as Transaction exposing (Certificate(..), Transaction, newBody, newWitnessSet)
 import Cardano.TxIntent as TxIntent exposing (ActionProposal(..), CertificateIntent(..), Fee(..), GovernanceState, SpendSource(..), TxFinalizationError(..), TxFinalized, TxIntent(..), TxOtherInfo(..), finalizeAdvanced)
@@ -26,6 +26,7 @@ suite : Test
 suite =
     describe "Cardano Tx building"
         [ okTxBuilding
+        , combinedRegistrationTests
         , failTxBuilding
         , balanceIntents
         ]
@@ -57,6 +58,136 @@ balanceIntents =
             \_ ->
                 balanceWithMe [ receiveAda 1 ]
                     |> Expect.equal (Ok [ receiveAda 0, spendAda 1, receiveAda 1 ])
+        ]
+
+
+combinedRegistrationTests : Test
+combinedRegistrationTests =
+    describe "Combined registration and vote delegation"
+        [ combinedRegistrationTest "register and delegate votes"
+            (\delegator ->
+                RegisterAndDelegateVotes
+                    { delegator = delegator, drep = AlwaysAbstain, deposit = ada 2 }
+            )
+            (\delegator ->
+                VoteRegDelegCert
+                    { delegator = delegator, drep = AlwaysAbstain, deposit = ada 2 }
+            )
+        , combinedRegistrationTest "register and delegate stake and votes"
+            (\delegator ->
+                RegisterAndDelegateStakeAndVotes
+                    { delegator = delegator
+                    , poolId = Bytes.dummy 28 "poolId"
+                    , drep = AlwaysNoConfidence
+                    , deposit = ada 2
+                    }
+            )
+            (\delegator ->
+                StakeVoteRegDelegCert
+                    { delegator = delegator
+                    , poolId = Bytes.dummy 28 "poolId"
+                    , drep = AlwaysNoConfidence
+                    , deposit = ada 2
+                    }
+            )
+        ]
+
+
+combinedRegistrationTest : String -> (Witness.Credential -> CertificateIntent) -> (Address.Credential -> Certificate) -> Test
+combinedRegistrationTest description makeIntent makeCertificate =
+    let
+        stakeKeyHash =
+            dummyCredentialHash "stk-me"
+
+        intents delegator =
+            [ Spend <|
+                FromWallet
+                    { address = testAddr.me
+                    , value = Value.onlyLovelace (ada 2)
+                    , guaranteedUtxos = []
+                    }
+            , IssueCertificate (makeIntent delegator)
+            ]
+    in
+    describe description
+        [ okTxTest "with a key credential, one deposit and the stake-key signature"
+            { govState = TxIntent.emptyGovernanceState
+            , localStateUtxos = [ makeAdaOutput 0 testAddr.me 5 ]
+            , evalScriptsCosts = \_ _ -> Ok []
+            , fee = twoAdaFee
+            , txOtherInfo = []
+            , txIntents = intents (WithKey stakeKeyHash)
+            }
+            (\_ ->
+                { tx =
+                    { newTx
+                        | body =
+                            { newBody
+                                | inputs = [ makeRef "0" 0 ]
+                                , outputs = [ Utxo.fromLovelace testAddr.me (ada 1) ]
+                                , fee = ada 2
+                                , certificates = [ makeCertificate (VKeyHash stakeKeyHash) ]
+                            }
+                    }
+                , expectedSignatures = [ dummyCredentialHash "key-me", stakeKeyHash ]
+                }
+            )
+        , test "evaluates a Plutus credential through the default finalizer" <|
+            \_ ->
+                let
+                    localStateUtxos =
+                        Utxo.refDictFromList
+                            [ makeAdaOutput 0 testAddr.me 20
+                            , makeAdaOutput 1 testAddr.me 5
+                            ]
+
+                    -- This certificate is the only Plutus use, so its intent must
+                    -- trigger script detection in the default evaluator.
+                    delegator =
+                        WithScript indexedScript.hash <|
+                            Witness.Plutus (indexedScript.witness 0)
+                in
+                case TxIntent.finalize localStateUtxos [] (intents delegator) of
+                    Err error ->
+                        Expect.fail (TxIntent.errorToString error)
+
+                    Ok finalized ->
+                        Expect.all
+                            [ \{ tx } ->
+                                Expect.equal
+                                    [ makeCertificate (ScriptHash indexedScript.hash) ]
+                                    tx.body.certificates
+                            , \{ tx } ->
+                                Expect.equal
+                                    [ Utxo.fromLovelace testAddr.me (Natural.sub (ada 18) tx.body.fee) ]
+                                    tx.body.outputs
+                            , \{ tx } ->
+                                Expect.equal
+                                    (Just [ Script.cborWrappedBytes indexedScript.plutus ])
+                                    tx.witnessSet.plutusV3Script
+                            , \{ tx } ->
+                                Expect.equal [ makeRef "1" 1 ] tx.body.collateral
+                            , \{ tx } ->
+                                Expect.notEqual Nothing tx.body.scriptDataHash
+                            , \{ expectedSignatures } ->
+                                Expect.equal [ dummyCredentialHash "key-me" ] expectedSignatures
+                            , \{ tx } ->
+                                case tx.witnessSet.redeemer of
+                                    Just [ redeemer ] ->
+                                        Expect.all
+                                            [ \r ->
+                                                Expect.equal
+                                                    ( Redeemer.Cert, 0, Data.Int Integer.zero )
+                                                    ( r.tag, r.index, r.data )
+                                            , \r -> Expect.greaterThan 0 r.exUnits.mem
+                                            , \r -> Expect.greaterThan 0 r.exUnits.steps
+                                            ]
+                                            redeemer
+
+                                    _ ->
+                                        Expect.fail "Expected exactly one evaluated certificate redeemer"
+                            ]
+                            finalized
         ]
 
 


### PR DESCRIPTION
API support for the [3 combined certificates](https://github.com/IntersectMBO/cardano-ledger/blob/9d4b20f3c293887f0b919b1f2847c9f7224d2661/eras/conway/impl/cddl/data/conway.cddl#L513-L520) that carry out registration along with other delegation actions:
- `account_registration_delegation_to_stake_pool_cert`
- `account_registration_delegation_to_drep_cert`
- `account_registration_delegation_to_stake_pool_and_drep_cert`

It also fixes the CBOR encoding of `AlwaysAbstain` and `AlwaysNoConfidence` to use `[2]` and `[3]` respectively (lists instead of bare integers, in accordance with [the ledger](https://github.com/IntersectMBO/cardano-ledger/blob/9d4b20f3c293887f0b919b1f2847c9f7224d2661/eras/conway/impl/cddl/data/conway.cddl#L508)).